### PR TITLE
Super synth

### DIFF
--- a/mri_super_synth/CMakeLists.txt
+++ b/mri_super_synth/CMakeLists.txt
@@ -4,7 +4,9 @@ install_configured(mri_super_synth DESTINATION bin)
 
 if (FSPYTHON_INSTALL_TREE)
    install(DIRECTORY SuperSynth DESTINATION ${FSPYTHON_INSTALL_PREFIX}/python/packages)
+   install(FILES SuperSynth/scripts/inference.py DESTINATION ${FSPYTHON_INSTALL_PREFIX}/ERC_bayesian_segmentation/scripts)
 else()
    install(DIRECTORY SuperSynth DESTINATION python/packages)
+   install(FILES SuperSynth/scripts/inference.py DESTINATION python/packages/ERC_bayesian_segmentation/scripts)
 endif()
 

--- a/mri_super_synth/CMakeLists.txt
+++ b/mri_super_synth/CMakeLists.txt
@@ -3,10 +3,10 @@ project(mri_super_synth)
 install_configured(mri_super_synth DESTINATION bin)
 
 if (FSPYTHON_INSTALL_TREE)
-   install(DIRECTORY SuperSynth DESTINATION ${FSPYTHON_INSTALL_PREFIX}/python/packages)
+   install(DIRECTORY SuperSynth/SuperSynth DESTINATION ${FSPYTHON_INSTALL_PREFIX}/python/packages)
    install(FILES SuperSynth/scripts/inference.py DESTINATION ${FSPYTHON_INSTALL_PREFIX}/ERC_bayesian_segmentation/scripts)
 else()
-   install(DIRECTORY SuperSynth DESTINATION python/packages)
+   install(DIRECTORY SuperSynth/SuperSynth DESTINATION python/packages)
    install(FILES SuperSynth/scripts/inference.py DESTINATION python/packages/ERC_bayesian_segmentation/scripts)
 endif()
 

--- a/mri_super_synth/mri_super_synth
+++ b/mri_super_synth/mri_super_synth
@@ -57,10 +57,16 @@ then
   exit 0
 fi
 
-# Try to find SuperSynth model
+# Try to find SuperSynth model and atlas files
 MODEL_FILE="$FREESURFER_HOME/models/SuperSynth_August_2025.pth"
-if [ ! -f "$MODEL_FILE"  ];
+ATLAS_FILE="$FREESURFER_HOME/python/packages/ERC_bayesian_segmentation/atlas_simplified/size.npy"
+
+# if model file or atlas files not found, print instructions for download and exit
+if [ ! -f "$MODEL_FILE" ] || [ ! -f "$ATLAS_FILE" ];
 then
+echo "Unable to located some dependencies, please follow the steps below to install them, then rerun the script."
+echo ""
+if [ ! -f "$MODEL_FILE" ]; then 
     echo " "
     echo "   Machine learning model file not found. Please download from from: "
     echo "     https://ftp.nmr.mgh.harvard.edu/pub/dist/lcnpublic/dist/SuperSynth_Iglesias_2025/SuperSynth_August_2025.pth "
@@ -75,7 +81,26 @@ then
     echo "      $FREESURFER_HOME/models/ "
     echo "   should now contain an additional file:SuperSynth_August_2025.pth"
     echo " "
-    exit 1
+fi
+if [ ! -f "$ATLAS_FILE" ]; then
+  echo " "
+  echo "   Atlas files not found. Please download atlas from: "
+  echo "      https://ftp.nmr.mgh.harvard.edu/pub/dist/lcnpublic/dist/Histo_Atlas_Iglesias_2023/atlas_simplified.zip "
+  echo "   and uncompress it into:  "
+  echo "      $FREESURFER_HOME/python/packages/ERC_bayesian_segmentation/ "
+  echo "   You only need to do this once. You can use the following three commands (may require root access): "
+  echo "      1: cd $FREESURFER_HOME/python/packages/ERC_bayesian_segmentation"
+  echo "      2a (in Linux): wget https://ftp.nmr.mgh.harvard.edu/pub/dist/lcnpublic/dist/Histo_Atlas_Iglesias_2023/atlas_simplified.zip "
+  echo "      2b (in MAC): curl -o atlas.zip https://ftp.nmr.mgh.harvard.edu/pub/dist/lcnpublic/dist/Histo_Atlas_Iglesias_2023/atlas_simplified.zip "
+  echo "      3. unzip atlas_simplified.zip"
+  echo " "
+  echo "   After correct extraction, the directory: "
+  echo "      $FREESURFER_HOME/python/packages/ERC_bayesian_segmentation/atlas_simplified "
+  echo "   should contain files: size.npy, label_001.npz, label_002.npz, ..."
+  echo " "
+
+fi
+exit 1    
 fi
 
 # Create command and run!


### PR DESCRIPTION
Updated the CMakeLists.txt - SuperSynth python package is no longer nested within another SuperSynth directory; install the inference.py file under the ERC_bayesian_segmentation scripts.

Added additional check for dependencies in the wrapper - This tool also depends on some of the atlas files that should be installed with the mri_histo_util tools (looks like just the 'atlas_simplified' is needed and this wrapper doesn't seem to have a way to specify the ATLAS_MODE, like in the histo util). Added an additional check for the atlas files and instructions for downloading and installing in the wrapper script.

We should work out a better way to structure the python dependencies. Would probably be best to package everything that has similar dependencies for your segmentation tools to keep the install clean, and make it easier for you to repurpose the code for other similar projects.